### PR TITLE
stop aborting search if searchText is empty

### DIFF
--- a/libs/simple-pdf-viewer/src/simplePdfViewer.component.ts
+++ b/libs/simple-pdf-viewer/src/simplePdfViewer.component.ts
@@ -658,9 +658,6 @@ export class SimplePdfViewerComponent implements OnInit, OnDestroy {
   public search(text: string, searchOptions: SimpleSearchOptions = SimpleSearchOptions.DEFAULT_OPTIONS): void {
     if (this.isDocumentLoaded()) {
       const searchText = text ? text.trim() : '';
-      if (!searchText) {
-        return;
-      }
       this.lastSearchText = text;
       this.searchPrevious = false;
       this.searchOptions = searchOptions;


### PR DESCRIPTION
Hi Viktor,

I'm proposing this change as I'm searching while the user types the search text. Thus, when the user deletes the last character in the search field (and the search text gets empty) the search aborts and the matches of the last search are displayed to the user.

What was the original purpose of the removed if-statement? Is it save to be removed? At least for my setting this change works.

Best regards,
Alex